### PR TITLE
Updating google search parsing to change '+' to '%2B'

### DIFF
--- a/node/bot.js
+++ b/node/bot.js
@@ -343,7 +343,7 @@ return bot
         if (content.match(/^felix google/gi)) {
             var text = content.split('google')[1].trim();
 
-            channel.send('here you go! <https://www.google.com/search?q=' + text.split(' ').join('+') + '>');
+            channel.send('here you go! <https://www.google.com/search?q=' + text.replace(/[+]/g, '%2B').split(' ').join('+') + '>');
         }
 
         if (content.match(/^(hi|what's up|yo|hey|hello) felix/gi)) {


### PR DESCRIPTION
For example, If you do felix google c++, the search results actually come up for 'c'

To avoid this, google replaces '+' in search term with '%2B'. Did the same here to fix the problem