### PR TITLE
Improved some felix run user interactions

### DIFF
--- a/node/bot.js
+++ b/node/bot.js
@@ -102,17 +102,20 @@ var handlers = {
         const content = message.content;
         const channel = message.channel;
 
-        var input_language = content.split('```', 1)[0].split(' ', 3)[2];
+        var input_language = content.split('```', 1)[0].split(' ', 3)[2] || null;
         // everything between the first felix run and ```
 
-        input_language = input_language.trim().to_lower_case();
-        // allow uppercase characters and extra whitespace
+        if(input_language){
+            // allow uppercase characters and extra whitespace
+            input_language = input_language.trim().to_lower_case();
+        }
 
-        var highlighting_language = content.split('```', 2)[1].split(' ', 1)[0];
-        // everything between the first ``` and the next space
+        var highlighting_language = (/```(.+)\s/g.exec(content) || [, null])[1];
+        // everything between the first ``` and the next whitespace character
 
 
-        
+
+        // if you add any languages please make sure to change 'highlighting_languages' as well
         const input_languages = {
             python: 'python3',
             python3: 'python3',
@@ -141,6 +144,9 @@ var handlers = {
         // sources:
         // https://sourceforge.net/p/discord/wiki/markdown_syntax/#md_ex_code
         // => http://pygments.org/docs/lexers/
+
+        // I wrote a small script that generates this list from the 'input_languages'
+        // feel free to message me @soruh#8824 on discord if you need it
         const highlighting_languages = {
             python: 'python3',
             py: 'python3',
@@ -170,12 +176,18 @@ var handlers = {
         };
         
         var language = null;
+
         if (input_languages.hasOwnProperty(input_language)) {
             language = input_languages[input_language];
         } else if(highlighting_languages.hasOwnProperty(highlighting_language)) {
             language = highlighting_languages[highlighting_language];
         } else {
-            channel.send(input_language + ' is not supported');
+            const invalid_language = input_language || highlighting_language;
+            if (invalid_language) {
+                channel.send("'" + invalid_language + "' is not supported");
+            } else {
+                channel.send('please specify a language');
+            }
             return;
         }
 

--- a/node/bot.js
+++ b/node/bot.js
@@ -194,18 +194,8 @@ return bot
             return handlers.state_change(message);
         }
 
-        if (content.match(/^felix run (js|javascript|python(2|3)?|node|c|c\+\+|cpp|ruby|go|r|cs|csharp|php|c#|nasm|asm|java|swift|brainfuck|bf)/gi)) {
-            return handlers.code(message);
-        }
-
-        if (content.match(/^(hi|what's up|yo|hey|hello) felix/gi)) {
-            message.reply('hello!');
-            return;
-        }
-
-        // easter eggs and various content
-        switch (content) {
-            case 'felix run':
+        if (content.match(/^felix run/gi)) {
+            if(content === "felix run"){
                 channel.send(
                     'i can run code!\n\n' +
                     '**here are my supported languages:**'+
@@ -214,7 +204,18 @@ return bot
                     'felix run js\n' +
                     '\\`\\`\\`\nyour code\n\\`\\`\\`'
                 );
-                break;
+            }else{
+                return handlers.code(message);
+            }
+        }
+
+        if (content.match(/^(hi|what's up|yo|hey|hello) felix/gi)) {
+            message.reply('hello!');
+            return;
+        }
+
+        // easter eggs
+        switch (content) {
             case 'html is a programming language':
                 message.reply('no it\'s not, don\'t be silly');
                 break;

--- a/node/bot.js
+++ b/node/bot.js
@@ -102,8 +102,18 @@ var handlers = {
         const content = message.content;
         const channel = message.channel;
 
-        var input_language = content.split('```')[0].split(' ')[2];
-        var language = {
+        var input_language = content.split('```', 1)[0].split(' ', 3)[2];
+        // everything between the first felix run and ```
+
+        input_language = input_language.trim().to_lower_case();
+        // allow uppercase characters and extra whitespace
+
+        var highlighting_language = content.split('```', 2)[1].split(' ', 1)[0];
+        // everything between the first ``` and the next space
+
+
+        
+        const input_languages = {
             python: 'python3',
             python3: 'python3',
             python2: 'python2',
@@ -126,9 +136,45 @@ var handlers = {
             swift: 'swift',
             brainfuck: 'brainfuck',
             bf: 'brainfuck',
-        }[input_language.trim().to_lower_case()] || null;
+        };
 
-        if (!language) {
+        // sources:
+        // https://sourceforge.net/p/discord/wiki/markdown_syntax/#md_ex_code
+        // => http://pygments.org/docs/lexers/
+        const highlighting_languages = {
+            python: 'python3',
+            py: 'python3',
+            sage: 'python3',
+            python3: 'python3',
+            py3: 'python3',
+            js: 'javascript',
+            javascript: 'javascript',
+            go: 'go',
+            rb: 'ruby',
+            ruby: 'ruby',
+            duby: 'ruby',
+            c: 'c',
+            cpp: 'cpp',
+            'c++': 'cpp',
+            csharp: 'csharp',
+            'c#': 'csharp',
+            php: 'php',
+            php3: 'php',
+            php4: 'php',
+            php5: 'php',
+            nasm: 'nasm',
+            java: 'java',
+            swift: 'swift',
+            brainfuck: 'brainfuck',
+            bf: 'brainfuck'
+        };
+        
+        var language = null;
+        if (input_languages.hasOwnProperty(input_language)) {
+            language = input_languages[input_language];
+        } else if(highlighting_languages.hasOwnProperty(highlighting_language)) {
+            language = highlighting_languages[highlighting_language];
+        } else {
             channel.send(input_language + ' is not supported');
             return;
         }
@@ -195,7 +241,7 @@ return bot
         }
 
         if (content.match(/^felix run/gi)) {
-            if(content === "felix run"){
+            if (content === "felix run") {
                 channel.send(
                     'i can run code!\n\n' +
                     '**here are my supported languages:**'+
@@ -204,7 +250,7 @@ return bot
                     'felix run js\n' +
                     '\\`\\`\\`\nyour code\n\\`\\`\\`'
                 );
-            }else{
+            } else {
                 return handlers.code(message);
             }
         }

--- a/node/bot.js
+++ b/node/bot.js
@@ -175,6 +175,20 @@ var handlers = {
             bf: 'brainfuck'
         };
         
+
+        const code_message = content.replace(/```.+\s/gi, '```');
+
+        const matches = /```((.|\n)+)```/gi.exec(code_message);
+
+        if (!matches) {
+            channel.send('no code present')
+            return;
+        }
+
+        const source = matches[1].trim();
+
+
+
         var language = null;
 
         if (input_languages.hasOwnProperty(input_language)) {
@@ -191,16 +205,7 @@ var handlers = {
             return;
         }
 
-        const code_message = content.replace(/```.+\s/gi, '```');
 
-        const matches = /```((.|\n)+)```/gi.exec(code_message);
-
-        if (!matches) {
-            channel.send('no code present')
-            return;
-        }
-
-        const source = matches[1].trim();
 
         return request
             ({

--- a/node/bot.js
+++ b/node/bot.js
@@ -105,7 +105,7 @@ var handlers = {
         var input_language = content.split('```', 1)[0].split(' ', 3)[2] || null;
         // everything between the first felix run and ```
 
-        if(input_language){
+        if (input_language) {
             // allow uppercase characters and extra whitespace
             input_language = input_language.trim().to_lower_case();
         }


### PR DESCRIPTION
- fixed a bug where Felix would completely ignore invalid languages, that didn't start with a valid language. so
`felix run jsXYZ` would result in a `jsXYZ is not supported` message
where as 
`felix run XYZ` would be ignored completely

- added syntax highlighting based language detection, so this is now valid:
felix run
\`\`\`js
console.log('test');
\`\`\`
