### PR TITLE
Make Felix respond to 'Felix ' and @ mention

### DIFF
--- a/python/bot.py
+++ b/python/bot.py
@@ -51,7 +51,7 @@ class Felix(Bot):
 
 
 client = Felix(
-    command_prefix=('felix ', '~ '),
+    command_prefix=('felix ', 'Felix ', '~ '),
     description='Hi I am Felix!',
     max_messages=15000
 )

--- a/python/bot.py
+++ b/python/bot.py
@@ -11,7 +11,7 @@ This bot requires discord.py
     pip install -U discord.py
 """
 from discord.ext.commands import Bot, CommandOnCooldown, MissingRequiredArgument
-from discord.ext.commands import CheckFailure
+from discord.ext.commands import CheckFailure, when_mentioned_or
 from aiohttp import ClientSession
 from os import path, listdir
 import json
@@ -51,7 +51,7 @@ class Felix(Bot):
 
 
 client = Felix(
-    command_prefix=('felix ', 'Felix ', '~ '),
+    command_prefix=when_mentioned_or('felix ', 'Felix ', '~ '),
     description='Hi I am Felix!',
     max_messages=15000
 )


### PR DESCRIPTION
In the discord we noted how Felix doesn't respond to 'Felix', which is a bit annoying when on phone and autocorrect capitalises the F. We also talked about how it would be nice to have felix be able to respond to direct mentions, and luckily there is already the functionality to add this as a prefix using [when_mentioned_or](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html?highlight=when_mentioned_or#discord.ext.commands.when_mentioned_or). Hopefully simple quality of life improvements for Felix!