### PR TITLE
Change to requirements.txt for easier python package management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM python:3.7.3-stretch
-RUN pip install -U discord.py && pip install -U matplotlib
+ADD requirements.txt /app/
+RUN pip install -U -r /app/requirements.txt 

--- a/readme.md
+++ b/readme.md
@@ -11,8 +11,7 @@ These instructions will get you a copy of the project up and running on your loc
 #### without docker
 ```
 git clone https://github.com/engineer-man/felix.git
-pip install -U discord.py
-pip install -U matplotlib
+pip install -U -r requirements.txt
 ```
 Duplicate `config.json.sample` and rename it `config.json` and update it with your own discord bot token.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+discord.py
+matplotlib


### PR DESCRIPTION
Currently if you wish to add a dependency, you have to both update the README and the Dockerfile. Using a requirements.txt file you only need to add your dep there and all run cases are handled.