### PR TITLE
Make member argument optional

### DIFF
--- a/python/cogs/general.py
+++ b/python/cogs/general.py
@@ -399,8 +399,10 @@ class General(commands.Cog, name='General'):
         name='memberinfo',
         aliases=['member']
     )
-    async def memberinfo(self, ctx, member: Member):
+    async def memberinfo(self, ctx, member: Member = None):
         """Provides information about the given member."""
+        if not member:
+            member = ctx.author
         url = 'https://emkc.org/api/v1/stats/discord/messages'
         params = [('discord_id', member.id)]
         async with self.client.session.get(url, params=params) as r:


### PR DESCRIPTION
Most of the time users like to check their own info. This eliminates the need to provide their own id/username and uses `ctx.author` instead.