### PR TITLE
Strip .png from end of location string

### DIFF
--- a/python/cogs/general.py
+++ b/python/cogs/general.py
@@ -582,6 +582,7 @@ class General(commands.Cog, name='General'):
           \u1160**units** (m/u/mM/uM): m = Metric | u = US | M = wind in M/s
 
           API used: https://en.wttr.in/:help"""
+        location = re.sub('(?:\.png)+$', '', location, flags=re.IGNORECASE)
         url = (
             'https://wttr.in/'
             f'{location}?{units}{days}{"" if days else "q"}nTAF'


### PR DESCRIPTION
Adding `.png` to the location would cause an error while trying to parse a received PNG as text.