### PR TITLE
Add purge_until command

### DIFF
--- a/python/cogs/purge.py
+++ b/python/cogs/purge.py
@@ -11,7 +11,7 @@ Only users that have an admin role can use the commands.
 
 import typing
 from discord.ext import commands
-from discord import User
+from discord import User, errors
 
 
 class Purge(commands.Cog, name='Purge'):
@@ -36,6 +36,26 @@ class Purge(commands.Cog, name='Purge'):
         channel = ctx.message.channel
         await ctx.message.delete()
         await channel.purge(limit=num_messages, check=None, before=None)
+        return True
+
+    @commands.command(
+        name='purge_until',
+        hidden=True,
+    )
+    async def purge_until(
+        self, ctx,
+        message_id: int,
+    ):
+        """Clear messages in a channel until the given message_id. Given ID is not deleted"""
+        channel = ctx.message.channel
+        try:
+            message = await channel.fetch_message(message_id)
+        except errors.NotFound:
+            await ctx.send("Message could not be found in this channel")
+            return
+
+        await ctx.message.delete()
+        await channel.purge(after=message)
         return True
 
     @commands.command(


### PR DESCRIPTION
This should behave pretty well for most cases, although I have no edge case tested it for a case such as giving it an ID wayyy in the past. The discord.py [implementation](https://github.com/Rapptz/discord.py/blob/6065cee7a04bf2a2a69fd12c7da5e835ef9382cf/discord/channel.py#L295) suggests it is able to handle this scenario fine by choosing different strategies for bulk deletion based on the use case. 