### PR TITLE
Added optional typing to the weather command

### DIFF
--- a/python/cogs/general.py
+++ b/python/cogs/general.py
@@ -19,6 +19,7 @@ Commands:
 
 import random
 import re
+import typing
 from datetime import datetime as dt
 from urllib.parse import quote
 from discord.ext import commands
@@ -589,8 +590,8 @@ class General(commands.Cog, name='General'):
     async def weather(
         self, ctx,
         location: str,
-        days: int = 0,
-        units: str = 'm',
+        days: typing.Optional[int] = 0,
+        units: typing.Optional[str] = 'm',
     ):
         """Get the current weather/forecast in a location
 
@@ -609,6 +610,9 @@ class General(commands.Cog, name='General'):
           \u1160**units** (m/u/mM/uM): m = Metric | u = US | M = wind in M/s
 
           API used: https://en.wttr.in/:help"""
+        if units not in ["m", "u", "mM", "uM"]:
+            location = f"{location} {units}"
+            units = "m"
         location = location.replace('.png', '')
         moon = location.startswith('moon')
         url = (


### PR DESCRIPTION
This allows the user to type a location with two words such as:
'Boston spa' or 'New york' without encountering an error that
the second word cannot be converted to an int. This also allows
the user to specify units without specifying a number of days.

It could be more robust to add a *args to capture days or units
missed due to the optional typing

![example 2](https://user-images.githubusercontent.com/34174223/75573042-f0629780-5a53-11ea-9926-c5625cfe79cc.PNG)
![example](https://user-images.githubusercontent.com/34174223/75573043-f0fb2e00-5a53-11ea-97a6-9a9c9a3be982.PNG)

