### PR TITLE
Cleanup regex

### DIFF
--- a/python/cogs/general.py
+++ b/python/cogs/general.py
@@ -116,7 +116,7 @@ class General(commands.Cog, name='General'):
             await msg.channel.send('hello')
 
         if re.search(
-            r'(?i)^felix should (i|he|she|they|we|@*)',
+            r'(?i)^felix should (i|he|she|they|we|<@!?\d+>)',
             msg.content
         ):
             if random.random() >= 0.5:

--- a/python/cogs/general.py
+++ b/python/cogs/general.py
@@ -97,8 +97,8 @@ class General(commands.Cog, name='General'):
             await msg.channel.send('` - directed by M. Night Shyamalan.`')
 
         if re.search(
-            r'(?i)(the|this) (current )?year is ' +
-            r'((almost|basically) )?(over|done|finished)',
+            r'(?i)(?:the|this) (?:current )?year is ' +
+            r'(?:almost |basically )?(?:over|done|finished)',
             msg.content
         ):
             await msg.channel.send(self.get_year_string())
@@ -110,13 +110,13 @@ class General(commands.Cog, name='General'):
             await msg.channel.send('😏 *sensible chuckle*')
 
         if re.search(
-            r'(?i)^(hi|what\'s up|yo|hey|hello) felix',
+            r'(?i)^(?:hi|what\'s up|yo|hey|hello) felix',
             msg.content
         ):
             await msg.channel.send('hello')
 
         if re.search(
-            r'(?i)^felix should (i|he|she|they|we|<@!?\d+>)',
+            r'(?i)^felix should (?:i|he|she|they|we|<@!?\d+>)',
             msg.content
         ):
             if random.random() >= 0.5:


### PR DESCRIPTION
`(?i)^felix should (i|he|she|they|we|@*)` is bad regex since `@*` can match nothing (making the other keywords useless). Also use non-capturing groups since they aren't used anywhere.