### PR TITLE
auto jail scam links from regex list

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -27,5 +27,9 @@
     "wolfram_key" : "",
     "github_key" : "",
     "aoc_key" : "",
-    "nasa_key": "DEMO_KEY"
+    "nasa_key": "DEMO_KEY",
+
+    "spam": [
+        "free nitro!",
+    ]
 }


### PR DESCRIPTION
add an array of scam links to config.json spam key array. allow us to target specific wording via regex to auto jail based on scam links hopefully help knock those bots quickly.