### PR TITLE
Live update sort fix

### DIFF
--- a/python/cogs/extra/aoc.py
+++ b/python/cogs/extra/aoc.py
@@ -29,10 +29,10 @@ KNOWN_USERS = {
     '676763': 'Tomzy',
     '995197': 'Ghostrunner0808',
     '959036': 'Bones',
-    '957883': 'Jason Terror',
     '996249': 'dev_null',
     '962475': 'dv_man',
     '419680': 'RuskyHacker',
+    '1155906': 'T2',
     }
 class AdventOfCode(commands.Cog, name='Advent of Code'):
     def __init__(self, client):

--- a/python/cogs/extra/aoc.py
+++ b/python/cogs/extra/aoc.py
@@ -34,7 +34,6 @@ KNOWN_USERS = {
     '962475': 'dv_man',
     '419680': 'RuskyHacker',
     }
-
 class AdventOfCode(commands.Cog, name='Advent of Code'):
     def __init__(self, client):
         self.client = client
@@ -64,10 +63,11 @@ class AdventOfCode(commands.Cog, name='Advent of Code'):
         msg = []
         for member_id, data in current_members.items():
             if member_id not in self.members:
-                msg.append(
+                msg.append((
+                    0,
                     f"#{data['name'].replace(' ','_')} " +
                     "has just joined the leaderboard."
-                )
+                ))
                 continue
             if data['stars'] == self.members[member_id]['stars']:
                 continue
@@ -85,16 +85,17 @@ class AdventOfCode(commands.Cog, name='Advent of Code'):
                 if puzzle not in previous_stats:
                     day, pzl = puzzle.split('-')
                     time = int(new_stats[day][pzl]['get_star_ts'])
-                    msg.append(
+                    msg.append((
+                        time,
                         f"#{data['name'].replace(' ', '_')} " +
                         f"solved: [{day} - {pzl}] " +
                         f"at [{datetime.fromtimestamp(time).strftime('%H:%M:%S')} UTC]"
-                    )
+                    ))
         if msg:
             await channel.send(
                 '\n'.join([
                     "```css",
-                    '\n'.join(msg),
+                    '\n'.join([txt for _, txt in sorted(msg)]),
                     "```"
                 ])
             )


### PR DESCRIPTION
Sometimes this would happen:
```
#Austin_Joachim solved: [2 - 2] at [15:25:55 UTC]
#Chuckinator2020 solved: [2 - 2] at [15:25:51 UTC]
```
Now the messages are sorted on timestamp.

I also updated the KNOWN_USERS dict to add my id and remove Jason's id because of this message in discord:
https://discord.com/channels/473161189120147456/778324114213175323/915997148405960715