### PR TITLE
change avatar asset to display user or default avatar

### DIFF
--- a/python/cogs/extra/aoc.py
+++ b/python/cogs/extra/aoc.py
@@ -220,7 +220,7 @@ class AdventOfCode(commands.Cog, name='Advent of Code'):
         )
         embed.set_footer(
             text=ctx.author.display_name,
-            icon_url=ctx.author.avatar.url
+            icon_url=ctx.author.display_avatar
         )
         await ctx.send(embed=embed)
 

--- a/python/cogs/general.py
+++ b/python/cogs/general.py
@@ -274,7 +274,7 @@ class General(commands.Cog, name='General'):
             e.set_image(url=gif_url)
             e.set_footer(
                 text=ctx.author.display_name,
-                icon_url=ctx.author.avatar.url
+                icon_url=ctx.author.display_avatar
             )
 
             await ctx.send(embed=e)
@@ -490,10 +490,10 @@ class General(commands.Cog, name='General'):
                 raise commands.BadArgument('Bad response from EMKC API')
             data = await r.json()
         embed = Embed(color=member.color)
-        embed.set_thumbnail(url=member.avatar.url)
+        embed.set_thumbnail(url=member.display_avatar)
         embed.set_footer(
             text=ctx.author.display_name,
-            icon_url=ctx.author.avatar.url
+            icon_url=ctx.author.display_avatar
         )
         message_count = data[0]['messages'] if data else 0
         guild_time = (dt.utcnow() - member.joined_at.replace(tzinfo=None)).total_seconds() / 86400
@@ -584,7 +584,7 @@ class General(commands.Cog, name='General'):
         )
         embed.set_footer(
             text=ctx.author.display_name,
-            icon_url=ctx.author.avatar.url
+            icon_url=ctx.author.display_avatar
         )
         await ctx.send(embed=embed)
     # ------------------------------------------------------------------------

--- a/python/cogs/hangman.py
+++ b/python/cogs/hangman.py
@@ -25,7 +25,7 @@ class HangmanGame:
         self._channel = channel
         self.color = author.color or 0x2ECC71
         self.user_name = author.display_name
-        self.user_avatar = author.avatar.url
+        self.user_avatar = author.display_avatar
         self.tries = TRIES
         self.correct = []
         self.incorrect = []

--- a/python/cogs/helpall.py
+++ b/python/cogs/helpall.py
@@ -31,7 +31,7 @@ class myHelpCommand(HelpCommand):
         if header:
             embed.set_author(
                 name=self.context.bot.description,
-                icon_url=self.context.bot.user.avatar.url
+                icon_url=self.context.bot.user.display_avatar
             )
         for category, entries in self.paginator:
             embed.add_field(

--- a/python/cogs/management.py
+++ b/python/cogs/management.py
@@ -527,7 +527,7 @@ class Management(commands.Cog, name='Management'):
             e = Embed(title='Full command that caused the error:',
                       description=orig_content)
             e.set_footer(text=error_source.author.display_name,
-                         icon_url=error_source.author.avatar.url)
+                         icon_url=error_source.author.display_avatar)
         await ctx.send(embed=e)
 
 


### PR DESCRIPTION
adjusted assets to show user set avatar asset or default avatar if not set on calls which return a users avatar which was throwing errors for the default discord avatars after recent discord.py update to felix.