### PR TITLE
Updated purge_user no longer deleting the command msg

### DIFF
--- a/python/cogs/purge.py
+++ b/python/cogs/purge.py
@@ -74,7 +74,6 @@ class Purge(commands.Cog, name='Purge'):
         def check(msg):
             return msg.author.id == user.id
 
-        await ctx.message.delete()
         for channel in await ctx.guild.fetch_channels():
             if type(channel) is TextChannel:
                 try:


### PR DESCRIPTION
purge_user was deleting the invocation message which was confusing. Should be fixed now.