### PR TITLE
Improvements to spam ls

### DIFF
--- a/python/cogs/spam_blocker.py
+++ b/python/cogs/spam_blocker.py
@@ -283,8 +283,10 @@ class SpamBlocker(commands.Cog, name='Spam'):
                 NUM_LEN = 25
                 res_to_show = res
                 if page != "all":
-                    start = int(page) * NUM_SPAM
-                    res_to_show = res[start:start+25]
+                    start = int(page) - 1 * NUM_SPAM
+                    if start == -24:
+                        start = 0
+                    res_to_show = res[start:start+NUM_SPAM]
                 all_spam = [f'{row.id:0>3} | {row.regex}' for row in res_to_show]
                 response = []
                 for _ in range(len(all_spam)):

--- a/python/cogs/spam_blocker.py
+++ b/python/cogs/spam_blocker.py
@@ -285,7 +285,7 @@ class SpamBlocker(commands.Cog, name='Spam'):
                 if page != "all":
                     start = (int(page) - 1) * NUM_LEN
                     res_to_show = res[start:start+NUM_SPAM]
-                all_spam = [f'{row.id:0>3} | {row.regex}' for row in res_to_show]
+                all_spam = [f'{row.id:3} | {row.regex}' for row in res_to_show]
                 response = []
                 for _ in range(len(all_spam)):
                     response.append('\n'.join(all_spam[NUM_SPAM - NUM_LEN:NUM_SPAM]))

--- a/python/cogs/spam_blocker.py
+++ b/python/cogs/spam_blocker.py
@@ -273,7 +273,7 @@ class SpamBlocker(commands.Cog, name='Spam'):
         name='list',
         aliases=['ls']
     )
-    async def current_spam_list(self, ctx):
+    async def current_spam_list(self, ctx, page="all"):
         """Lists all current items in the spam database"""
         async with async_session() as db:
             async with db.begin():
@@ -281,7 +281,11 @@ class SpamBlocker(commands.Cog, name='Spam'):
                 res = await scd.get_all_spam()
                 NUM_SPAM = 25
                 NUM_LEN = 25
-                all_spam = [f'{row.id:0>3} | {row.regex}' for row in res]
+                res_to_show = res
+                if page != "all":
+                    start = int(page) * NUM_SPAM
+                    res_to_show = res[start:start+25]
+                all_spam = [f'{row.id:0>3} | {row.regex}' for row in res_to_show]
                 response = []
                 for _ in range(len(all_spam)):
                     response.append('\n'.join(all_spam[NUM_SPAM - NUM_LEN:NUM_SPAM]))

--- a/python/cogs/spam_blocker.py
+++ b/python/cogs/spam_blocker.py
@@ -41,7 +41,7 @@ class SpamBlocker(commands.Cog, name='Spam'):
         self.construct_spam_dict.start()
 
 
-    def make_spam_list(num_spam: int, amount: int, spam: list):
+    def make_spam_list(self, num_spam: int, amount: int, spam: list):
         spam_list_text = '\n'.join(spam[num_spam - amount:num_spam])
         return spam_list_text
 

--- a/python/cogs/spam_blocker.py
+++ b/python/cogs/spam_blocker.py
@@ -281,7 +281,7 @@ class SpamBlocker(commands.Cog, name='Spam'):
                 res = await scd.get_all_spam()
                 NUM_SPAM = 25
                 NUM_LEN = 25
-                all_spam = [f'  {row.id} | {row.regex}' if row.id < 10 else f' {row.id} | {row.regex}' for row in res]
+                all_spam = [f'{row.id:0>3} | {row.regex}' for row in res]
                 response = []
                 for _ in range(len(all_spam)):
                     response.append('\n'.join(all_spam[NUM_SPAM - NUM_LEN:NUM_SPAM]))

--- a/python/cogs/spam_blocker.py
+++ b/python/cogs/spam_blocker.py
@@ -42,9 +42,8 @@ class SpamBlocker(commands.Cog, name='Spam'):
 
 
     def make_spam_list(num_spam: int, amount: int, spam: list):
-        spam_list = []
-        spam_list.append('\n'.join(spam[num_spam - amount:num_spam]))
-        return spam_list
+        spam_list_text = '\n'.join(spam[num_spam - amount:num_spam])
+        return spam_list_text
 
 
     @tasks.loop(count=1)

--- a/python/cogs/spam_blocker.py
+++ b/python/cogs/spam_blocker.py
@@ -283,9 +283,8 @@ class SpamBlocker(commands.Cog, name='Spam'):
                 NUM_LEN = 25
                 res_to_show = res
                 if page != "all":
-                    start = int(page) - 1 * NUM_SPAM
-                    if start == -24:
-                        start = 0
+                    start = (int(page) - 1) * NUM_LEN
+                    print(start)
                     res_to_show = res[start:start+NUM_SPAM]
                 all_spam = [f'{row.id:0>3} | {row.regex}' for row in res_to_show]
                 response = []

--- a/python/cogs/spam_blocker.py
+++ b/python/cogs/spam_blocker.py
@@ -284,7 +284,6 @@ class SpamBlocker(commands.Cog, name='Spam'):
                 res_to_show = res
                 if page != "all":
                     start = (int(page) - 1) * NUM_LEN
-                    print(start)
                     res_to_show = res[start:start+NUM_SPAM]
                 all_spam = [f'{row.id:0>3} | {row.regex}' for row in res_to_show]
                 response = []

--- a/python/cogs/spam_blocker.py
+++ b/python/cogs/spam_blocker.py
@@ -293,7 +293,7 @@ class SpamBlocker(commands.Cog, name='Spam'):
                 all_spam = [f'{row.id:3} | {row.regex}' for row in res_to_show]
                 response = []
                 for _ in range(len(all_spam)):
-                    response.append('\n'.join(all_spam[NUM_SPAM - NUM_LEN:NUM_SPAM]))
+                    response.append(self.make_spam_list(NUM_SPAM, NUM_LEN, all_spam))
                     NUM_SPAM += NUM_LEN
                 for block in response:
                     await ctx.send(f'```{"".join(block)}```') if len(block) > 0 else None


### PR DESCRIPTION
This pull request contains improvements to the `felix spam ls` command.

- [x] pad spam id numbers with spaces
- [x] implement pagination
  - [x] decide page size (25; felix sends spam rules in bundles of 25 per message so logical)
  - [x] decide whether to start at zero or one