### PR TITLE
Get spam IDs from db instead of enumerate()

### DIFF
--- a/python/cogs/spam_blocker.py
+++ b/python/cogs/spam_blocker.py
@@ -282,8 +282,9 @@ class SpamBlocker(commands.Cog, name='Spam'):
                 res = await scd.get_all_spam()
 
         await ctx.send(
-            file=File(BytesIO('\n'.join(f'{n:3} | {s}'
-                      for n,s in enumerate([row.regex for row in res], 1)).encode()),
+            file=File(BytesIO('\n'.join(f'{spam_item[0]:3} | {spam_item[1]}'
+                      for spam_item in zip([row.id for row in res],
+                                           [row.regex for row in res])).encode()),
                       filename="spam-ls.txt"),
             content="Here is the spam list"
         )


### PR DESCRIPTION
This will make sure that spam IDs are always accurate. With this PR, we fetch the spam ID from the database instead of guessing it with `enumerate()`.

Testing I did:
- I manually accessed `felix.sqlite` and manually inserted a row into `spam` with ID 53 when the last spam was of ID 50.
  - With this PR, the dumped file shows 53 on the manually inserted rule.
  - With the current behavior (without this PR), the dumped file incorrectly showed 51 as the ID of the spam rule. Running `felix spam who 51` on the rule results in a response that the rule does not exist. Doing the same for 53 shows that the rule does indeed exist.

You can see in the `Felix Command Thread` of the `#moderator-report` channel of the Engineer Man Discord of how the rule numbers are slightly inaccurate.